### PR TITLE
Refonte du Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,17 @@
-JFLAGS = -g
-JC = javac
-JVM= java
-LINT = -Xlint:all
+JC := javac
+JFLAGS := -g -Xlint:all
+JVM := java
 
-.SUFFIXES: .java .class
+FMT := google-java-format
+FMTFLAGS := -i -a
 
-.java.class:
-	$(JC) $(LINT) $*.java
-	$(JVM) $(MAIN)
-	jar -cvf Project.jar ServerTCP.class
+all:
+	$(JC) $(JFLAGS) *.java
 
-CLASSES = \
-	ServerTCP.java
+indent:
+	$(FMT) $(FMTFLAGS) *.java
 
-MAIN = ServerTCP
+clean:
+	$(RM) *.class *~
 
-default: classes
-
-classes: $(CLASSES:.java=.class)
-
-run: $(ServerTCP).class
-	$(JVM) $(MAIN)
+.PHONY: all indent clean


### PR DESCRIPTION
Améliorations principales :
- Sépare la compilation et l’exécution. Un appel à `make` devrait simplement compiler, il ne devrait pas lancer le programme.
- Supprime la règle maison pour les `.class` et la remplace par une règle qui compile tout. C’est un piège de faire dépendre un fichier `.class` seulement du fichier `.java` correspondant. Par exemple ici, si je modifie `ServerThread.java` puis que je fais `make`, il ne va rien recompiler. Parce qu’il va regarder uniquement si `ServerTCP.class` est à jour, et comme on lui a dit qu’il ne dépend que de `ServerTCP.java`, qui n’a pas été modifié, il va considérer qu’il est à jour. Pour corriger ça j’ai simplement mis une unique cible `all` qui compile tout. Java permet de faire ça facilement, donc autant en profiter.
- Ajoute une cible `clean` pour supprimer les fichiers inutiles à garder, et une cible `indent` pour indenter les fichiers de code.
- Supprime la création automatique d’une archive après chaque compilation et exécution. Pourquoi créer une archive `.jar` à chaque compilation ? Ou à chaque exécution du serveur ? S’il n’y a pas de raison, il vaut peut-être mieux l’enlever ?
- Supprime la cible pour lancer le serveur. Est-ce que ça nous fait vraiment gagner quelque chose d’avoir une cible pour lancer le serveur ? Si on veut être exhaustif il nous faudrait 4 cibles : quelque chose comme `run-server`, `run-client`, `run-server-no-encryption` et `run-client-no-encryption` et alors est-ce qu’on gagne encore quelque chose à écrire `make run-client-no-encryption` par rapport à `java ClientTCPNotSecure` ?

Améliorations secondaires :
- Regroupe les flags pour `javac` dans une seule variable. Est-ce qu’il y a une raison de les garder séparés ?
- Assigne les variables avec `:=` au lieu de `=`. La différence entre les deux est expliquée dans [la documentation de GNU make](https://www.gnu.org/software/make/manual/make.html#Flavors). Mon expérience est que `:=` a la sémantique la plus intuitive, qui cause le moins de bugs, et qu’on devrait utiliser `:=` partout par défaut et n’utiliser `=` que quand on a une bonne raison de le faire. Est-ce qu’ici il y a une bonne raison de le faire ?
- Ajoute une cible `.PHONY`, pour éviter le problème qui pourrait se poser le jour où le dépôt contiendra un fichier nommé `all` ou `clean`. Ça a peu de chance d’arriver mais c’est une bonne pratique, qui permet aussi au lecteur de distinguer les noms de cibles qui désignent des fichiers à fabriquer de ceux qui n’en sont pas.
- Supprime la cible `.SUFFIXES`. Je n’ai pas l’impression qu’on ait besoin de `.SUFFIXES` ici. Est-ce qu’on en a besoin ?

Améliorations qui ne sont plus pertinentes mais ça peut vous intéresser tout de même :
- Mieux vaut utiliser la notation moderne pour les règles maisons : `%.class: %.java` au lieu de `.java.class:`.
